### PR TITLE
[fix] Sway: broken application launcher: dmenu -> wmenu

### DIFF
--- a/archinstall/default_profiles/desktops/sway.py
+++ b/archinstall/default_profiles/desktops/sway.py
@@ -38,7 +38,7 @@ class SwayProfile(XorgProfile):
 			"swaylock",
 			"swayidle",
 			"waybar",
-			"dmenu",
+			"wmenu",
 			"brightnessctl",
 			"grim",
 			"slurp",


### PR DESCRIPTION
## The issue being fixed:
After a fresh installation using archinstall with the sway desktop, the default application launcher accessible via mod+d was not working. This is because sway has changed its default application launcher from dmenu to wmenu (see https://github.com/swaywm/sway/commit/ab9b164e524532a99c6e383b4c6f1eaa60c8d721 and https://github.com/swaywm/sway/commit/b44015578a3d53cdd9436850202d4405696c1f52).

## PR Description:
This commit ensures that wmenu is installed, resolving the issue and providing the expected application launcher functionality for new sway installations.

## Tests and Checks
- [ ] I have tested the code!<br>
  <!--
      After submitting your PR, an ISO can be downloaded below the PR description. After testing it you can check the box
      You can do manual tests too, like isolated function tests, just something!
  -->
